### PR TITLE
Honor RUSTFLAGS's target-cpu if given

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -158,9 +158,27 @@ fn write_tables() {
     not(any(target_os = "android", target_os = "ios"))
 ))]
 fn compile_simd_c() {
+    fn guess_target_cpu() -> String {
+        // Copied and adapted from https://github.com/alexcrichton/proc-macro2/blob/4173a21dc497c67326095e438ff989cc63cd9279/build.rs#L115
+        // Licensed under Apache-2.0 + MIT (compatible because we're Apache-2.0)
+        let rustflags = env::var_os("RUSTFLAGS");
+        if let Some(rustflags) = rustflags {
+            for mut flag in rustflags.to_string_lossy().split(' ') {
+                if flag.starts_with("-C") {
+                    flag = &flag["-C".len()..];
+                }
+                if flag.starts_with("target-cpu=") {
+                    return flag["target-cpu=".len()..].to_owned()
+                }
+            }
+        }
+
+        "native".to_string()
+    }
+
     cc::Build::new()
         .opt_level(3)
-        .flag("-march=native")
+        .flag(&format!("-march={}", guess_target_cpu()))
         .flag("-std=c11")
         .file("simd_c/reedsolomon.c")
         .compile("reedsolomon");

--- a/build.rs
+++ b/build.rs
@@ -160,7 +160,7 @@ fn write_tables() {
 fn compile_simd_c() {
     fn guess_target_cpu() -> String {
         // Copied and adapted from https://github.com/alexcrichton/proc-macro2/blob/4173a21dc497c67326095e438ff989cc63cd9279/build.rs#L115
-        // Licensed under Apache-2.0 + MIT (compatible because we're Apache-2.0)
+        // Licensed under Apache-2.0 + MIT (compatible because we're MIT)
         let rustflags = env::var_os("RUSTFLAGS");
         if let Some(rustflags) = rustflags {
             for mut flag in rustflags.to_string_lossy().split(' ') {


### PR DESCRIPTION
#### problem

cpu instruction detection is done at compile time, which isn't compatible for cross-compiling.

#### solution

To fix [a cross compile issuse](https://github.com/solana-labs/solana/pull/9212/files#r401331218), first we need to make it possible  for `solana-reed-solomon` to accept/honor given `RUSTFLAGS`.

So, we're forcibly reinterpreting `RUSTFLAGS`'s `cpu-type` as `CFLAGS`'s `-march`, but it's safe, I think.

That's because as far as I'm aware, the acceptable value of `target-cpu` is universal OSS C and Rust toolchains, because `rust` and `clang` shares the same backend (LLVM), then LLVM was in turn heavily influenced by the GCC because of the compatibility.