### PR TITLE
Added conditional compilation for cross-compiling for Aarch64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -153,7 +153,10 @@ fn write_tables() {
 
 #[cfg(all(
     feature = "simd-accel",
-    any(target_arch = "x86_64", target_arch = "aarch64"),
+    any(
+        all(host_arch = "x86_64", target_arch = "x86_64"),
+        all(host_arch = "aarch64", target_arch = "aarch64")
+    ),
     not(target_env = "msvc"),
     not(any(target_os = "android", target_os = "ios"))
 ))]
@@ -161,6 +164,21 @@ fn compile_simd_c() {
     cc::Build::new()
         .opt_level(3)
         .flag("-march=native")
+        .flag("-std=c11")
+        .file("simd_c/reedsolomon.c")
+        .compile("reedsolomon");
+}
+
+#[cfg(all(
+    feature = "simd-accel",
+    any(
+        all(not(host_arch = "x86_64"), target_arch = "x86_64"),
+        all(not(host_arch = "aarch64"), target_arch = "aarch64")
+    )
+))]
+fn compile_simd_c() {
+    cc::Build::new()
+        .opt_level(3)
         .flag("-std=c11")
         .file("simd_c/reedsolomon.c")
         .compile("reedsolomon");

--- a/build.rs
+++ b/build.rs
@@ -153,10 +153,7 @@ fn write_tables() {
 
 #[cfg(all(
     feature = "simd-accel",
-    any(
-        all(host_arch = "x86_64", target_arch = "x86_64"),
-        all(host_arch = "aarch64", target_arch = "aarch64")
-    ),
+    any(target_arch = "x86_64", target_arch = "aarch64"),
     not(target_env = "msvc"),
     not(any(target_os = "android", target_os = "ios"))
 ))]
@@ -164,21 +161,6 @@ fn compile_simd_c() {
     cc::Build::new()
         .opt_level(3)
         .flag("-march=native")
-        .flag("-std=c11")
-        .file("simd_c/reedsolomon.c")
-        .compile("reedsolomon");
-}
-
-#[cfg(all(
-    feature = "simd-accel",
-    any(
-        all(not(host_arch = "x86_64"), target_arch = "x86_64"),
-        all(not(host_arch = "aarch64"), target_arch = "aarch64")
-    )
-))]
-fn compile_simd_c() {
-    cc::Build::new()
-        .opt_level(3)
         .flag("-std=c11")
         .file("simd_c/reedsolomon.c")
         .compile("reedsolomon");

--- a/src/core.rs
+++ b/src/core.rs
@@ -53,10 +53,10 @@ use super::ReconstructShard;
 /// # Example
 ///
 /// ```
-/// # #[macro_use] extern crate reed_solomon_erasure;
-/// # use reed_solomon_erasure::*;
+/// # #[macro_use] extern crate solana_reed_solomon_erasure;
+/// # use solana_reed_solomon_erasure::*;
 /// # fn main () {
-/// use reed_solomon_erasure::galois_8::Field;
+/// use solana_reed_solomon_erasure::galois_8::Field;
 /// let r: ReedSolomon<Field> = ReedSolomon::new(3, 2).unwrap();
 ///
 /// let mut sbs = ShardByShard::new(&r);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,8 +2,8 @@
 ///
 /// # Example
 /// ```rust
-/// # #[macro_use] extern crate reed_solomon_erasure;
-/// # use reed_solomon_erasure::*;
+/// # #[macro_use] extern crate solana_reed_solomon_erasure;
+/// # use solana_reed_solomon_erasure::*;
 /// # fn main () {
 /// let shards: Vec<Vec<u8>> = shards!([1, 2, 3],
 ///                                    [4, 5, 6]);
@@ -23,7 +23,7 @@ macro_rules! shards {
 /// # Examples
 /// ## Byte arrays on stack to `Vec<&[u8]>`
 /// ```rust
-/// # #[macro_use] extern crate reed_solomon_erasure;
+/// # #[macro_use] extern crate solana_reed_solomon_erasure;
 /// # fn main () {
 /// let array: [[u8; 3]; 2] = [[1, 2, 3],
 ///                             [4, 5, 6]];
@@ -34,7 +34,7 @@ macro_rules! shards {
 /// ```
 /// ## Byte arrays on stack to `Vec<&mut [u8]>` (borrow mutably)
 /// ```rust
-/// # #[macro_use] extern crate reed_solomon_erasure;
+/// # #[macro_use] extern crate solana_reed_solomon_erasure;
 /// # fn main () {
 /// let mut array: [[u8; 3]; 2] = [[1, 2, 3],
 ///                                [4, 5, 6]];
@@ -45,7 +45,7 @@ macro_rules! shards {
 /// ```
 /// ## Byte arrays on stack to `SmallVec<[&mut [u8]; 32]>` (borrow mutably)
 /// ```rust
-/// # #[macro_use] extern crate reed_solomon_erasure;
+/// # #[macro_use] extern crate solana_reed_solomon_erasure;
 /// # extern crate smallvec;
 /// # use smallvec::SmallVec;
 /// # fn main () {
@@ -59,7 +59,7 @@ macro_rules! shards {
 /// ```
 /// ## Shard array to `SmallVec<[&mut [u8]; 32]>` (borrow mutably)
 /// ```rust
-/// # #[macro_use] extern crate reed_solomon_erasure;
+/// # #[macro_use] extern crate solana_reed_solomon_erasure;
 /// # extern crate smallvec;
 /// # use smallvec::SmallVec;
 /// # fn main () {
@@ -73,7 +73,7 @@ macro_rules! shards {
 /// ```
 /// ## Shard array to `Vec<&mut [u8]>` (borrow mutably) into `SmallVec<[&mut [u8]; 32]>` (move)
 /// ```rust
-/// # #[macro_use] extern crate reed_solomon_erasure;
+/// # #[macro_use] extern crate solana_reed_solomon_erasure;
 /// # extern crate smallvec;
 /// # use smallvec::SmallVec;
 /// # fn main () {


### PR DESCRIPTION
When cross-compiling, the option `-march=native` is not available. This PR fixes the error which was caused by using this option when the host and the target were different.

I also took the liberty of fixing the doc crate name in tests because the CI was failing on those.